### PR TITLE
Mobile next/prev change

### DIFF
--- a/pickee_frontend/src/components/RecommendationCarousel/RecommendationCarousel.css
+++ b/pickee_frontend/src/components/RecommendationCarousel/RecommendationCarousel.css
@@ -167,6 +167,11 @@
     padding-left: 0;
 }
 
+.tablet .recommendation-carousel,
+.phone .recommendation-carousel {
+    position: static;
+}
+
 .phone .recommendation-carousel {
     padding: 4rem 0 2rem;
 }
@@ -175,4 +180,16 @@
 .phone .recommendation-carousel__swiper-slide img {
     width: 18rem;
     height: 28rem;
+}
+
+.phone .recommendation-carousel__swiper-button-prev,
+.phone .recommendation-carousel__swiper-button-next {
+    top: 15rem;
+    transform: none;
+}
+
+.tablet .recommendation-carousel__swiper-button-prev,
+.tablet .recommendation-carousel__swiper-button-next {
+    top: 25rem;
+    transform: none;;
 }

--- a/pickee_frontend/src/components/RecommendationCarousel/RecommendationCarousel.js
+++ b/pickee_frontend/src/components/RecommendationCarousel/RecommendationCarousel.js
@@ -51,6 +51,7 @@ export default {
                 effect: "coverflow",
                 centeredSlides: true,
                 initialSlide: 1,
+                allowTouchMove: false,
                 slidesPerView: "auto",
                 spaceBetween: 0,
                 grabCursor: false,

--- a/pickee_frontend/src/components/RecommendationCarousel/RecommendationCarousel.vue
+++ b/pickee_frontend/src/components/RecommendationCarousel/RecommendationCarousel.vue
@@ -1,6 +1,10 @@
 <template>
     <div class="recommendation-carousel">
-        <swiper :options="swiperOption" ref="mySwiper" class="recommendation-carousel__swiper">
+        <swiper 
+            :options="swiperOption" 
+            ref="mySwiper" 
+            class="recommendation-carousel__swiper"
+        >
             <swiper-slide
                 class="recommendation-carousel__swiper-slide"
                 v-for="slide in swiperSlides"


### PR DESCRIPTION
I've disabled the swipe on mobile and tablet and restored arrows to change prev/next.
This is the only thing I can do at this moment to enable change of the description on mobile.